### PR TITLE
Remove redundant hook

### DIFF
--- a/src/useRafDebouncedValue.tsx
+++ b/src/useRafDebouncedValue.tsx
@@ -11,11 +11,5 @@ export function useRafDebouncedValue<T>(value: T) {
     };
   }, [value, setDebouncedState]);
 
-  useEffect(() => {
-    return () => {
-      queued.current && cancelAnimationFrame(queued.current);
-    };
-  }, []);
-
   return [debouncedState];
 }


### PR DESCRIPTION
`componentDidMount` and `componentWillUnmount` is also performed when deps array passed to `useEffect` is not empty.